### PR TITLE
chore: prepare 0.2.5 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,14 @@ PromptForge is a desktop application designed to streamline the process of creat
 4.  **Create:** Start creating, organizing, and refining your prompts!
 
 For detailed instructions on usage and features, please refer to the [Functional Manual](./FUNCTIONAL_MANUAL.md).
+
+## Release Workflow
+
+Maintainers preparing a new GitHub release should follow these steps:
+
+1. **Update Versioning & Notes:** Increment the version in `package.json` and add a matching entry to [`VERSION_LOG.md`](./VERSION_LOG.md) summarizing the changes.
+2. **Build the Application:** Run `npm install` (if needed) and `npm run build` to ensure the renderer bundle is up-to-date.
+3. **Package & Publish:** Use `npm run release` to invoke `electron-builder` with publishing enabled. See the [Technical Manual](./TECHNICAL_MANUAL.md#build-and-release-process) for platform-specific considerations.
+4. **Draft the GitHub Release:** Upload the generated artifacts in `release/` to the GitHub Releases page and include the highlights from the latest version log entry.
+
+These steps help keep the published binaries and documentation in sync for every tagged version.

--- a/TECHNICAL_MANUAL.md
+++ b/TECHNICAL_MANUAL.md
@@ -14,6 +14,7 @@ This document provides a technical overview of the PromptForge application's arc
     -   [Storage Service](#storage-service)
     -   [LLM Service](#llm-service)
     -   [Component Breakdown](#component-breakdown)
+5.  [Build and Release Process](#build-and-release-process)
 
 ---
 
@@ -114,3 +115,17 @@ This module handles all communication with the external Large Language Model.
 -   **`SettingsView.tsx`:** Manages all application settings. It features a two-column layout with navigation on the left and scroll-linked content sections on the right. It handles LLM provider configuration, appearance settings, and advanced options like JSON editing.
 -   **`CommandPalette.tsx`:** A dropdown component that displays a filterable list of available commands. It is positioned relative to the search input in the title bar and handles keyboard navigation for selecting and executing actions.
 -   **`StatusBar.tsx`:** The bottom bar of the application. Its role is now focused on displaying the LLM connection status and providing dropdowns for selecting the LLM provider and model.
+
+---
+
+## 5. Build and Release Process
+
+PromptForge ships via GitHub Releases using `electron-builder`. Follow this checklist when preparing a new public version:
+
+1. **Version Bump:** Update `package.json` with the new semantic version and document the highlights in [`VERSION_LOG.md`](./VERSION_LOG.md).
+2. **Dependency Install:** Run `npm install` to ensure all dependencies (including Electron) are present before building.
+3. **Build Renderer Bundle:** Execute `npm run build` to compile the renderer assets into the `dist/` directory.
+4. **Package Artifacts:** Run `npm run release` to build platform-specific installers inside the `release/` directory. This command automatically invokes `electron-builder --publish always` so CI or local environments can upload assets.
+5. **Validate Output:** Before drafting the GitHub release, smoke test the generated binaries and confirm they include the updated manuals referenced in `extraResources`.
+
+Documenting this process ensures the release workflow stays reproducible for contributors and maintainers alike.

--- a/VERSION_LOG.md
+++ b/VERSION_LOG.md
@@ -1,5 +1,11 @@
 # Version Log
 
+## v0.2.5
+
+### 🛠 Maintenance & Documentation
+- **Release Documentation:** Added explicit release workflow guidance to the technical manual so that maintainers can confidently package and publish new versions without missing required steps.
+- **Project Overview Refresh:** Clarified the README with a new release workflow section that links to the primary documentation set for quicker onboarding ahead of the 0.2.5 release.
+
 ## v0.2.4
 
 ### 🐛 Bug Fixes & Minor Enhancements

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptforge",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "An application to manage and refine LLM prompts.",
   "main": "dist/main.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump PromptForge to version 0.2.5 and document the release in VERSION_LOG.md
- add a release workflow overview to the README and expand the technical manual with a detailed build/release checklist

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dff68cde74833292bdc908274747ee