### PR TITLE
Make tree layout spacing configurable

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -676,6 +676,8 @@ const App: React.FC = () => {
                                     onRenameTemplate={handleRenameTemplate}
                                     onNewTemplate={handleNewTemplate}
                                     onNewFromTemplate={() => setCreateFromTemplateOpen(true)}
+                                    treeNodeSpacing={settings.treeNodeSpacing}
+                                    treeIndentSize={settings.treeIndentSize}
                                 />
                             </aside>
                             <div 

--- a/components/PromptList.tsx
+++ b/components/PromptList.tsx
@@ -19,10 +19,27 @@ interface PromptListProps {
   onToggleExpand: (id: string) => void;
   onMoveUp: (id: string) => void;
   onMoveDown: (id: string) => void;
+  nodeSpacing: number;
+  indentSize: number;
 }
 
-const PromptList: React.FC<PromptListProps> = ({ 
-  tree, prompts, selectedIds, focusedItemId, onSelectNode, onDeleteNode, onRenameNode, onMoveNode, onCopyNodeContent, searchTerm, expandedIds, onToggleExpand, onMoveUp, onMoveDown
+const PromptList: React.FC<PromptListProps> = ({
+  tree,
+  prompts,
+  selectedIds,
+  focusedItemId,
+  onSelectNode,
+  onDeleteNode,
+  onRenameNode,
+  onMoveNode,
+  onCopyNodeContent,
+  searchTerm,
+  expandedIds,
+  onToggleExpand,
+  onMoveUp,
+  onMoveDown,
+  nodeSpacing,
+  indentSize,
 }) => {
   const [isRootDropping, setIsRootDropping] = useState(false);
   
@@ -70,7 +87,7 @@ const PromptList: React.FC<PromptListProps> = ({
         onDragOver={handleRootDragOver}
         onDragLeave={handleRootDragLeave}
     >
-        <ul className="space-y-0.5 p-2">
+        <ul className="p-2 flex flex-col list-none" style={{ rowGap: `${nodeSpacing}px` }}>
         {tree.map((node, index) => (
             <PromptTreeItem
                 key={node.id}
@@ -90,6 +107,8 @@ const PromptList: React.FC<PromptListProps> = ({
                 onMoveDown={onMoveDown}
                 canMoveUp={index > 0}
                 canMoveDown={index < tree.length - 1}
+                nodeSpacing={nodeSpacing}
+                indentSize={indentSize}
             />
         ))}
         {prompts.length === 0 && (

--- a/components/PromptList.tsx
+++ b/components/PromptList.tsx
@@ -87,7 +87,7 @@ const PromptList: React.FC<PromptListProps> = ({
         onDragOver={handleRootDragOver}
         onDragLeave={handleRootDragLeave}
     >
-        <ul className="p-2 flex flex-col list-none" style={{ rowGap: `${nodeSpacing}px` }}>
+        <ul className="p-2 flex flex-col list-none">
         {tree.map((node, index) => (
             <PromptTreeItem
                 key={node.id}

--- a/components/PromptTreeItem.tsx
+++ b/components/PromptTreeItem.tsx
@@ -158,6 +158,9 @@ const PromptTreeItem: React.FC<PromptTreeItemProps> = (props) => {
     setDropPosition(null);
   };
   
+  const indentOffset = Math.max(level, 0) * indentSize;
+  const paddingBlock = Math.max(nodeSpacing / 2, 0);
+
   return (
     <li
       ref={itemRef}
@@ -166,16 +169,17 @@ const PromptTreeItem: React.FC<PromptTreeItemProps> = (props) => {
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
-      style={{ paddingLeft: `${level * indentSize}px` }}
       className="relative"
       data-item-id={node.id}
     >
+      <div className="relative" style={{ marginLeft: `${indentOffset}px` }}>
         <div
             onClick={(e) => !isRenaming && onSelectNode(node.id, e)}
             onDoubleClick={(e) => !isRenaming && handleRenameStart(e)}
-            className={`w-full text-left p-1.5 rounded-md group flex justify-between items-center transition-colors duration-150 text-sm relative focus:outline-none ${
+            className={`w-full text-left px-1.5 rounded-md group flex justify-between items-center transition-colors duration-150 text-sm relative focus:outline-none ${
                 isSelected ? 'bg-background text-text-main' : 'hover:bg-border-color/30 text-text-secondary hover:text-text-main'
             } ${isFocused ? 'ring-2 ring-primary ring-offset-[-2px] ring-offset-secondary' : ''}`}
+            style={{ paddingTop: `${paddingBlock}px`, paddingBottom: `${paddingBlock}px` }}
         >
             <div className="flex items-center gap-2 flex-1 truncate">
                 {isFolder && node.children.length > 0 ? (
@@ -227,14 +231,15 @@ const PromptTreeItem: React.FC<PromptTreeItemProps> = (props) => {
                 </div>
             )}
         </div>
-        
-        {dropPosition && <div className={`absolute left-0 right-0 h-0.5 bg-primary pointer-events-none ${
+
+        {dropPosition && <div className={`pointer-events-none absolute left-0 right-0 h-0.5 bg-primary ${
             dropPosition === 'before' ? 'top-0' : dropPosition === 'after' ? 'bottom-0' : ''
         }`} />}
-        {dropPosition === 'inside' && <div className="absolute inset-0 border-2 border-primary rounded-md pointer-events-none bg-primary/10" />}
+        {dropPosition === 'inside' && <div className="pointer-events-none absolute inset-0 border-2 border-primary rounded-md bg-primary/10" />}
+      </div>
 
         {isFolder && isExpanded && (
-            <ul className="flex flex-col list-none" style={{ rowGap: `${nodeSpacing}px` }}>
+            <ul className="flex flex-col list-none">
                 {node.children.map((childNode, index) => (
                     <PromptTreeItem
                         key={childNode.id}

--- a/components/PromptTreeItem.tsx
+++ b/components/PromptTreeItem.tsx
@@ -24,6 +24,8 @@ interface PromptTreeItemProps {
   onMoveDown: (id: string) => void;
   canMoveUp: boolean;
   canMoveDown: boolean;
+  indentSize: number;
+  nodeSpacing: number;
 }
 
 // Helper function to determine drop position based on mouse coordinates within an element
@@ -68,6 +70,8 @@ const PromptTreeItem: React.FC<PromptTreeItemProps> = (props) => {
     onMoveDown,
     canMoveUp,
     canMoveDown,
+    indentSize,
+    nodeSpacing,
   } = props;
   
   const [isRenaming, setIsRenaming] = useState(false);
@@ -162,7 +166,7 @@ const PromptTreeItem: React.FC<PromptTreeItemProps> = (props) => {
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
-      style={{ paddingLeft: `${level * 16}px` }}
+      style={{ paddingLeft: `${level * indentSize}px` }}
       className="relative"
       data-item-id={node.id}
     >
@@ -230,15 +234,17 @@ const PromptTreeItem: React.FC<PromptTreeItemProps> = (props) => {
         {dropPosition === 'inside' && <div className="absolute inset-0 border-2 border-primary rounded-md pointer-events-none bg-primary/10" />}
 
         {isFolder && isExpanded && (
-            <ul>
+            <ul className="flex flex-col list-none" style={{ rowGap: `${nodeSpacing}px` }}>
                 {node.children.map((childNode, index) => (
-                    <PromptTreeItem 
-                        key={childNode.id} 
-                        {...props} 
-                        node={childNode} 
+                    <PromptTreeItem
+                        key={childNode.id}
+                        {...props}
+                        node={childNode}
                         level={level + 1}
                         canMoveUp={index > 0}
                         canMoveDown={index < node.children.length - 1}
+                        indentSize={indentSize}
+                        nodeSpacing={nodeSpacing}
                     />
                 ))}
             </ul>

--- a/components/SettingsView.tsx
+++ b/components/SettingsView.tsx
@@ -280,7 +280,7 @@ const AppearanceSettingsSection: React.FC<SectionProps> = ({ settings, setCurren
                             id="treeNodeSpacing"
                             type="range"
                             min="0"
-                            max="16"
+                            max="24"
                             step="1"
                             value={settings.treeNodeSpacing}
                             onChange={(e) => setCurrentSettings(prev => ({ ...prev, treeNodeSpacing: Number(e.target.value) }))}
@@ -294,8 +294,8 @@ const AppearanceSettingsSection: React.FC<SectionProps> = ({ settings, setCurren
                         <input
                             id="treeIndentSize"
                             type="range"
-                            min="8"
-                            max="48"
+                            min="0"
+                            max="40"
                             step="1"
                             value={settings.treeIndentSize}
                             onChange={(e) => setCurrentSettings(prev => ({ ...prev, treeIndentSize: Number(e.target.value) }))}

--- a/components/SettingsView.tsx
+++ b/components/SettingsView.tsx
@@ -274,6 +274,36 @@ const AppearanceSettingsSection: React.FC<SectionProps> = ({ settings, setCurren
                         <span className="font-semibold text-text-main tabular-nums min-w-[50px] text-right">{settings.uiScale}%</span>
                     </div>
                 </SettingRow>
+                <SettingRow label="Tree Row Spacing" description="Control the vertical spacing between items in the prompt tree.">
+                    <div className="flex items-center gap-4 w-60">
+                        <input
+                            id="treeNodeSpacing"
+                            type="range"
+                            min="0"
+                            max="16"
+                            step="1"
+                            value={settings.treeNodeSpacing}
+                            onChange={(e) => setCurrentSettings(prev => ({ ...prev, treeNodeSpacing: Number(e.target.value) }))}
+                            className="w-full h-2 bg-border-color rounded-lg appearance-none cursor-pointer range-slider"
+                        />
+                        <span className="font-semibold text-text-main tabular-nums min-w-[50px] text-right">{settings.treeNodeSpacing}px</span>
+                    </div>
+                </SettingRow>
+                <SettingRow label="Tree Indent" description="Adjust how far nested items are indented in the prompt tree.">
+                    <div className="flex items-center gap-4 w-60">
+                        <input
+                            id="treeIndentSize"
+                            type="range"
+                            min="8"
+                            max="48"
+                            step="1"
+                            value={settings.treeIndentSize}
+                            onChange={(e) => setCurrentSettings(prev => ({ ...prev, treeIndentSize: Number(e.target.value) }))}
+                            className="w-full h-2 bg-border-color rounded-lg appearance-none cursor-pointer range-slider"
+                        />
+                        <span className="font-semibold text-text-main tabular-nums min-w-[50px] text-right">{settings.treeIndentSize}px</span>
+                    </div>
+                </SettingRow>
                 <SettingRow label="Icon Set" description="Customize the look of icons throughout the application.">
                     <div className="grid grid-cols-3 gap-3 w-80">
                          <CardButton name="Heroicons" value="heroicons" isSelected={settings.iconSet === 'heroicons'} onClick={(v) => setCurrentSettings(s => ({...s, iconSet: v}))}>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -28,6 +28,8 @@ interface SidebarProps {
   onRenameTemplate: (id: string, newTitle: string) => void;
   onNewTemplate: () => void;
   onNewFromTemplate: () => void;
+  treeNodeSpacing: number;
+  treeIndentSize: number;
 }
 
 type NavigableItem = { id: string; type: 'prompt' | 'folder' | 'template'; parentId: string | null; };
@@ -285,6 +287,8 @@ const Sidebar: React.FC<SidebarProps> = (props) => {
               onToggleExpand={props.onToggleExpand}
               onMoveUp={handleMoveUp}
               onMoveDown={handleMoveDown}
+              nodeSpacing={props.treeNodeSpacing}
+              indentSize={props.treeIndentSize}
           />
 
           {/* --- Templates Section --- */}

--- a/constants.ts
+++ b/constants.ts
@@ -22,6 +22,8 @@ export const DEFAULT_SETTINGS: Settings = {
   autoSaveLogs: false,
   allowPrerelease: false,
   uiScale: 100,
+  treeNodeSpacing: 2,
+  treeIndentSize: 16,
 };
 
 export const EXAMPLE_TEMPLATES: Omit<PromptTemplate, 'id' | 'createdAt' | 'updatedAt'>[] = [

--- a/hooks/useSettings.ts
+++ b/hooks/useSettings.ts
@@ -41,6 +41,12 @@ export const useSettings = () => {
         if (loadedSettings.uiScale === undefined) {
           loadedSettings.uiScale = 100;
         }
+        if (loadedSettings.treeNodeSpacing === undefined) {
+          loadedSettings.treeNodeSpacing = DEFAULT_SETTINGS.treeNodeSpacing;
+        }
+        if (loadedSettings.treeIndentSize === undefined) {
+          loadedSettings.treeIndentSize = DEFAULT_SETTINGS.treeIndentSize;
+        }
 
 
         // If provider name is missing but URL is present, try to discover it.

--- a/types.ts
+++ b/types.ts
@@ -36,6 +36,8 @@ export interface Settings {
   autoSaveLogs: boolean;
   allowPrerelease: boolean;
   uiScale: number;
+  treeNodeSpacing: number;
+  treeIndentSize: number;
 }
 
 export type LogLevel = 'DEBUG' | 'INFO' | 'WARNING' | 'ERROR';


### PR DESCRIPTION
## Summary
- add settings for prompt tree row spacing and indent including defaults and migrations
- apply the configurable spacing values when rendering the sidebar tree
- expose new sliders in the appearance section so users can tweak the tree layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0e5888da48332a689d9748942434d