### PR TITLE
chore: prepare 0.2.6 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For detailed instructions on usage and features, please refer to the [Functional
 
 Maintainers preparing a new GitHub release should follow these steps:
 
-1. **Update Versioning & Notes:** Increment the version in `package.json` and add a matching entry to [`VERSION_LOG.md`](./VERSION_LOG.md) summarizing the changes.
+1. **Update Versioning & Notes:** Increment the version in `package.json`, confirm the Markdown manuals reflect the current behavior, and add a matching entry to [`VERSION_LOG.md`](./VERSION_LOG.md) summarizing the changes.
 2. **Build the Application:** Run `npm install` (if needed) and `npm run build` to ensure the renderer bundle is up-to-date.
 3. **Package & Publish:** Use `npm run release` to invoke `electron-builder` with publishing enabled. See the [Technical Manual](./TECHNICAL_MANUAL.md#build-and-release-process) for platform-specific considerations.
 4. **Draft the GitHub Release:** Upload the generated artifacts in `release/` to the GitHub Releases page and include the highlights from the latest version log entry.

--- a/TECHNICAL_MANUAL.md
+++ b/TECHNICAL_MANUAL.md
@@ -122,7 +122,7 @@ This module handles all communication with the external Large Language Model.
 
 PromptForge ships via GitHub Releases using `electron-builder`. Follow this checklist when preparing a new public version:
 
-1. **Version Bump:** Update `package.json` with the new semantic version and document the highlights in [`VERSION_LOG.md`](./VERSION_LOG.md).
+1. **Version Bump & Docs Review:** Update `package.json` with the new semantic version, verify Markdown manuals reflect the current behavior, and document the highlights in [`VERSION_LOG.md`](./VERSION_LOG.md).
 2. **Dependency Install:** Run `npm install` to ensure all dependencies (including Electron) are present before building.
 3. **Build Renderer Bundle:** Execute `npm run build` to compile the renderer assets into the `dist/` directory.
 4. **Package Artifacts:** Run `npm run release` to build platform-specific installers inside the `release/` directory. This command automatically invokes `electron-builder --publish always` so CI or local environments can upload assets.

--- a/VERSION_LOG.md
+++ b/VERSION_LOG.md
@@ -1,5 +1,11 @@
 # Version Log
 
+## v0.2.6
+
+### 🛠 Maintenance & Documentation
+- **Release Prep Checklist:** Updated documentation to emphasize verifying Markdown guides before tagging a release and recorded the 0.2.6 notes for maintainers.
+- **Version Bump:** Incremented the application version to v0.2.6 in configuration files to match the upcoming release.
+
 ## v0.2.5
 
 ### 🛠 Maintenance & Documentation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptforge",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "An application to manage and refine LLM prompts.",
   "main": "dist/main.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump the application version to 0.2.6
- document the 0.2.6 maintenance release in VERSION_LOG
- refresh release workflow guidance to include a documentation review step

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0f2f15b748332b791c5e75936822f