### PR TITLE
Prepare v0.2.7 release documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ For detailed instructions on usage and features, please refer to the [Functional
 
 Maintainers preparing a new GitHub release should follow these steps:
 
-1. **Update Versioning & Notes:** Increment the version in `package.json`, confirm the Markdown manuals reflect the current behavior, and add a matching entry to [`VERSION_LOG.md`](./VERSION_LOG.md) summarizing the changes.
+1. **Update Versioning & Notes:** Increment the version in `package.json`, confirm the Markdown manuals reflect the current behavior, and add a matching entry to [`VERSION_LOG.md`](./VERSION_LOG.md) summarizing the fixes or documentation updates that should appear in the public release notes.
 2. **Build the Application:** Run `npm install` (if needed) and `npm run build` to ensure the renderer bundle is up-to-date.
 3. **Package & Publish:** Use `npm run release` to invoke `electron-builder` with publishing enabled. See the [Technical Manual](./TECHNICAL_MANUAL.md#build-and-release-process) for platform-specific considerations.
-4. **Draft the GitHub Release:** Upload the generated artifacts in `release/` to the GitHub Releases page and include the highlights from the latest version log entry.
+4. **Draft the GitHub Release:** Upload the generated artifacts in `release/` to the GitHub Releases page, then copy the highlights from the latest version log entry into the release notes and verify that the summary matches the final documentation.
 
 These steps help keep the published binaries and documentation in sync for every tagged version.
 

--- a/TECHNICAL_MANUAL.md
+++ b/TECHNICAL_MANUAL.md
@@ -122,10 +122,10 @@ This module handles all communication with the external Large Language Model.
 
 PromptForge ships via GitHub Releases using `electron-builder`. Follow this checklist when preparing a new public version:
 
-1. **Version Bump & Docs Review:** Update `package.json` with the new semantic version, verify Markdown manuals reflect the current behavior, and document the highlights in [`VERSION_LOG.md`](./VERSION_LOG.md).
+1. **Version Bump & Docs Review:** Update `package.json` with the new semantic version, verify Markdown manuals reflect the current behavior, and capture the highlights in [`VERSION_LOG.md`](./VERSION_LOG.md) so the release notes can be copied without additional edits.
 2. **Dependency Install:** Run `npm install` to ensure all dependencies (including Electron) are present before building.
 3. **Build Renderer Bundle:** Execute `npm run build` to compile the renderer assets into the `dist/` directory.
 4. **Package Artifacts:** Run `npm run release` to build platform-specific installers inside the `release/` directory. This command automatically invokes `electron-builder --publish always` so CI or local environments can upload assets.
-5. **Validate Output:** Before drafting the GitHub release, smoke test the generated binaries and confirm they include the updated manuals referenced in `extraResources`.
+5. **Validate Output & Notes:** Before drafting the GitHub release, smoke test the generated binaries, confirm they include the updated manuals referenced in `extraResources`, and double-check that the draft release notes match the latest version log entry.
 
 Documenting this process ensures the release workflow stays reproducible for contributors and maintainers alike.

--- a/VERSION_LOG.md
+++ b/VERSION_LOG.md
@@ -1,5 +1,11 @@
 # Version Log
 
+## v0.2.7
+
+### 🛠 Maintenance & Documentation
+- **Release Notes Alignment:** Clarified the README and technical manual checklists so maintainers copy the latest version log entry into the GitHub release notes and validate documentation before publishing.
+- **Version Bump:** Incremented the application version to v0.2.7 in configuration files in preparation for the release.
+
 ## v0.2.6
 
 ### 🛠 Maintenance & Documentation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptforge",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "An application to manage and refine LLM prompts.",
   "main": "dist/main.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump the application version to 0.2.7 for the upcoming release
- clarify the README and technical manual release workflows so maintainers copy the latest version log entry into GitHub release notes
- add a v0.2.7 maintenance entry to VERSION_LOG.md capturing the documentation updates

## Testing
- Not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68e15fddfc7c8332995ce8661e6aff12